### PR TITLE
[screensaver.biogenesis] 2.3.0

### DIFF
--- a/screensaver.biogenesis/addon.xml.in
+++ b/screensaver.biogenesis/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.biogenesis"
-  version="2.2.2"
+  version="2.3.0"
   name="BioGenesis"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required